### PR TITLE
fix: drop if len(fields) <= 1, using fields.Field

### DIFF
--- a/swagger_marshmallow_codegen/dispatcher.py
+++ b/swagger_marshmallow_codegen/dispatcher.py
@@ -50,8 +50,6 @@ class FormatDispatcher:
         self.def_map = self.load_def_map(self.type_map) if use_def_map else {}
 
     def dispatch(self, pair, field):
-        if pair.type == "object" and len(field) <= 1:
-            return "marshmallow.fields:Field"
         return self.type_map.get(pair) or self.type_map.get((pair[0], None))
 
     def handle_validator(self, c, value):


### PR DESCRIPTION
refs https://github.com/podhmo/swagger-marshmallow-codegen/issues/42#issuecomment-527757033

yaml
```yaml
definitions:
  Product:
    properties:
      name:
        type: string
      price:
        type: integer
  ProductList:
    properties:
      products:
        description: Contains the list of products
        type: array
        items: 
          $ref: "#/definitions/Product"
```

output is 

```py

class Product(Schema):
    name = fields.String()
    price = fields.Integer()


class ProductList(Schema):
    products = fields.List(fields.Field('Product'), description='Contains the list of products')
```